### PR TITLE
fix: title of serialports dose not visible

### DIFF
--- a/src/tools/serialport-server/Main.vue
+++ b/src/tools/serialport-server/Main.vue
@@ -213,7 +213,7 @@ export default {
             let serialports = await window.SerialPort.list();
             this.serialportOptions.serialports = [];
             for ( let i=0; i<serialports.length; i++ ) {
-                this.serialportOptions.serialports.push(serialports[i].path);
+                this.serialportOptions.serialports.push(serialports[i].path || serialports[i].title);
             }
 
             if ( 0 == this.path.trim().length || 1 == this.serialportOptions.serialports.length ) {


### PR DESCRIPTION
修复在 Mac 下串口名称在下拉列表中不显示的问题